### PR TITLE
* bump lager to 3.9.2 to fix build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             {platform_define, "^[0-9]+", namespaced_types},
             {parse_transform, lager_transform}]}.
 
-{deps, [lager,
+{deps, [{lager, "3.9.2"},
         folsom,
         cowboy,
         jsx,


### PR DESCRIPTION
this fixes failing builds as below due to lager dependency locked to lower version as 3.8.0. 

explicit dependency to latest lager 3.9.2 set.

```
===> Compiling erldns
===> Compiling _build/default/lib/erldns/src/erldns_zone_loader.erl failed
_build/default/lib/erldns/src/erldns_zone_loader.erl:none: error in parse transform 'lager_transform':
exception error: bad argument
  in function  integer_to_list/1
     called as integer_to_list({29,7})
     *** argument 1: not an integer
  in call from lager_transform:make_varname/2 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 271)
  in call from lager_transform:do_transform/5 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 176)
  in call from lager_transform:'-transform_statement/2-lc$^0/1-0-'/2 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 116)
  in call from lager_transform:'-transform_statement/2-lc$^0/1-0-'/2 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 116)
  in call from lager_transform:transform_statement/2 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 114)
  in call from lager_transform:'-transform_statement/2-lc$^0/1-0-'/2 (/Users/dns/projects/dnsimple/erldns-metrics/_build/default/lib/lager/src/lager_transform.erl, line 116)
```