### PR TITLE
Adopt Erlfmt

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,14 +1,26 @@
 %%-*- mode: erlang -*-
 {cover_enabled, true}.
+{erl_opts, [
+    debug_info,
+    fail_on_warning,
+    {platform_define, "^[0-9]+", namespaced_types},
+    {parse_transform, lager_transform}
+]}.
 
-{erl_opts, [debug_info, fail_on_warning,
-            {platform_define, "^[0-9]+", namespaced_types},
-            {parse_transform, lager_transform}]}.
+{project_plugins, [
+    erlfmt
+]}.
 
-{deps, [{lager, "3.9.2"},
-        folsom,
-        cowboy,
-        jsx,
-        dns_erlang,
-        erldns
-       ]}.
+{deps, [
+    {lager, "3.9.2"},
+    folsom,
+    cowboy,
+    jsx,
+    dns_erlang,
+    erldns
+]}.
+
+{erlfmt, [
+    write,
+    {print_width, 140}
+]}.

--- a/src/erldns_metrics.app.src
+++ b/src/erldns_metrics.app.src
@@ -1,22 +1,22 @@
 % -*- mode: Erlang; -*-
-{application, erldns_metrics,
- [{description, "Erlang Authoritative DNS Server Metrics API"},
-  {vsn, "1.0.0"},
-  {licenses, ["MIT"]},
-  {mod, { erldns_metrics_app, []}},
-  {applications, [kernel,
-                  stdlib,
-                  inets,
-                  crypto,
-                  lager,
-                  ssl,
-                  observer,
-                  bear,
-                  folsom,
-                  cowlib,
-                  ranch,
-                  cowboy,
-                  erldns]}
-  ]}.
-
-
+{application, erldns_metrics, [
+    {description, "Erlang Authoritative DNS Server Metrics API"},
+    {vsn, "1.0.0"},
+    {licenses, ["MIT"]},
+    {mod, {erldns_metrics_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        inets,
+        crypto,
+        lager,
+        ssl,
+        observer,
+        bear,
+        folsom,
+        cowlib,
+        ranch,
+        cowboy,
+        erldns
+    ]}
+]}.

--- a/src/erldns_metrics.erl
+++ b/src/erldns_metrics.erl
@@ -19,176 +19,195 @@
 
 -export([start_link/0]).
 
--export([metrics/0, stats/0, vm/0, ets/0, process_metrics/0, filtered_metrics/0, filtered_stats/0, filtered_vm/0, filtered_ets/0, filtered_process_metrics/0]).
+-export([
+    metrics/0,
+    stats/0,
+    vm/0,
+    ets/0,
+    process_metrics/0,
+    filtered_metrics/0,
+    filtered_stats/0,
+    filtered_vm/0,
+    filtered_ets/0,
+    filtered_process_metrics/0
+]).
 
 -define(DEFAULT_PORT, 8082).
 
 % Gen server hooks
--export([init/1,
+-export([
+    init/1,
     handle_call/3,
     handle_cast/2,
     handle_info/2,
     terminate/2,
     code_change/3
-  ]).
+]).
 
 -record(state, {}).
 
 %% Not part of gen server
 
 metrics() ->
-  lists:map(
-    fun(Name) ->
-        {Name, folsom_metrics:get_metric_value(Name)}
-    end, folsom_metrics:get_metrics()).
+    lists:map(
+        fun(Name) ->
+            {Name, folsom_metrics:get_metric_value(Name)}
+        end,
+        folsom_metrics:get_metrics()
+    ).
 
 filtered_metrics() ->
-  filter_metrics(metrics()).
+    filter_metrics(metrics()).
 
 stats() ->
-  Histograms = [udp_handoff_histogram, tcp_handoff_histogram, request_handled_histogram],
-  lists:map(
-    fun(Name) ->
-        {Name, folsom_metrics:get_histogram_statistics(Name)}
-    end, Histograms).
+    Histograms = [udp_handoff_histogram, tcp_handoff_histogram, request_handled_histogram],
+    lists:map(
+        fun(Name) ->
+            {Name, folsom_metrics:get_histogram_statistics(Name)}
+        end,
+        Histograms
+    ).
 
 filtered_stats() ->
-  filter_stats(stats()).
+    filter_stats(stats()).
 
 % Functions to clean up metrics so they can be returned as JSON.
 filter_metrics(Metrics) ->
-  filter_metrics(Metrics, []).
+    filter_metrics(Metrics, []).
 
 filter_metrics([], FilteredMetrics) ->
-  FilteredMetrics;
-filter_metrics([{Name, History = [{Timestamp, _Values}|_Rest]}|Rest], FilteredMetrics) when is_number(Timestamp) ->
-  filter_metrics(Rest, FilteredMetrics ++ [{Name, filter_history_entries(History)}]);
-filter_metrics([{Name, Metrics}|Rest], FilteredMetrics) ->
-  filter_metrics(Rest, FilteredMetrics ++ [{Name, Metrics}]).
+    FilteredMetrics;
+filter_metrics([{Name, History = [{Timestamp, _Values} | _Rest]} | Rest], FilteredMetrics) when is_number(Timestamp) ->
+    filter_metrics(Rest, FilteredMetrics ++ [{Name, filter_history_entries(History)}]);
+filter_metrics([{Name, Metrics} | Rest], FilteredMetrics) ->
+    filter_metrics(Rest, FilteredMetrics ++ [{Name, Metrics}]).
 
 filter_history_entries(HistoryEntries) ->
-  filter_history_entries(HistoryEntries, []).
+    filter_history_entries(HistoryEntries, []).
 filter_history_entries([], FilteredHistoryEntries) ->
-  FilteredHistoryEntries;
-filter_history_entries([{Timestamp, Values}|Rest], FilteredHistoryEntries) ->
-  filter_history_entries(Rest, FilteredHistoryEntries ++ [filter_history_entry(Timestamp, Values)]).
+    FilteredHistoryEntries;
+filter_history_entries([{Timestamp, Values} | Rest], FilteredHistoryEntries) ->
+    filter_history_entries(Rest, FilteredHistoryEntries ++ [filter_history_entry(Timestamp, Values)]).
 
 filter_history_entry(Timestamp, Values) ->
-  [{<<"timestamp">>, Timestamp}, {<<"values">>, lists:map(fun({event, Value}) -> Value end, Values)}].
+    [{<<"timestamp">>, Timestamp}, {<<"values">>, lists:map(fun({event, Value}) -> Value end, Values)}].
 
 % Functions to clean up the stats so they can be returned as JSON.
 filter_stats(Stats) ->
-  filter_stats(Stats, []).
+    filter_stats(Stats, []).
 
 filter_stats([], FilteredStats) ->
-  FilteredStats;
-filter_stats([{Name, Stats}|Rest], FilteredStats) ->
-  filter_stats(Rest, FilteredStats ++ [{Name, filter_stat_set(Stats)}]).
+    FilteredStats;
+filter_stats([{Name, Stats} | Rest], FilteredStats) ->
+    filter_stats(Rest, FilteredStats ++ [{Name, filter_stat_set(Stats)}]).
 
 filter_stat_set(Stats) ->
-  filter_stat_set(Stats, []).
+    filter_stat_set(Stats, []).
 
 filter_stat_set([], FilteredStatSet) ->
-  FilteredStatSet;
-filter_stat_set([{percentile, Percentiles}|Rest], FilteredStatSet) ->
-  filter_stat_set(Rest, FilteredStatSet ++ [{percentile, keys_to_strings(Percentiles)}]);
-filter_stat_set([{histogram, _}|Rest], FilteredStatSet) ->
-  filter_stat_set(Rest, FilteredStatSet);
-filter_stat_set([Pair|Rest], FilteredStatSet) ->
-  filter_stat_set(Rest, FilteredStatSet ++ [Pair]).
+    FilteredStatSet;
+filter_stat_set([{percentile, Percentiles} | Rest], FilteredStatSet) ->
+    filter_stat_set(Rest, FilteredStatSet ++ [{percentile, keys_to_strings(Percentiles)}]);
+filter_stat_set([{histogram, _} | Rest], FilteredStatSet) ->
+    filter_stat_set(Rest, FilteredStatSet);
+filter_stat_set([Pair | Rest], FilteredStatSet) ->
+    filter_stat_set(Rest, FilteredStatSet ++ [Pair]).
 
 vm() ->
-  [
-    {<<"memory">>, folsom_vm_metrics:get_memory()}
-  ].
+    [
+        {<<"memory">>, folsom_vm_metrics:get_memory()}
+    ].
 
 filtered_vm() ->
-  vm().
+    vm().
 
 ets() ->
-  [
-    {<<"ets">>, ets_metrics()}
-  ].
+    [
+        {<<"ets">>, ets_metrics()}
+    ].
 
 filtered_ets() ->
-  lists:map(
-    fun(TableData) ->
-        {
-          proplists:get_value(name, TableData),
-          [
-            {compressed, proplists:get_value(compressed, TableData)},
-            {size, proplists:get_value(size, TableData)},
-            {type, atom_to_binary(proplists:get_value(type, TableData), latin1)},
-            {protection, atom_to_binary(proplists:get_value(protection, TableData), latin1)}
-          ]
-        }
-  end, ets_metrics()).
+    lists:map(
+        fun(TableData) ->
+            {
+                proplists:get_value(name, TableData),
+                [
+                    {compressed, proplists:get_value(compressed, TableData)},
+                    {size, proplists:get_value(size, TableData)},
+                    {type, atom_to_binary(proplists:get_value(type, TableData), latin1)},
+                    {protection, atom_to_binary(proplists:get_value(protection, TableData), latin1)}
+                ]
+            }
+        end,
+        ets_metrics()
+    ).
 
 ets_metrics() ->
-  lists:map(fun(Name) -> ets:info(Name) end, ets:all()).
+    lists:map(fun(Name) -> ets:info(Name) end, ets:all()).
 
 keys_to_strings(Pairs) ->
-  lists:map(
-    fun({K, V}) ->
-        {list_to_binary(lists:flatten(io_lib:format("~p", [K]))), V}
-    end, Pairs).
+    lists:map(
+        fun({K, V}) ->
+            {list_to_binary(lists:flatten(io_lib:format("~p", [K]))), V}
+        end,
+        Pairs
+    ).
 
 process_metrics() ->
-  lists:map(
-    fun(ProcessName) ->
-        Pid = whereis(ProcessName),
-        {
-          ProcessName,
-          [
-            process_info(Pid, memory),
-            process_info(Pid, heap_size),
-            process_info(Pid, stack_size),
-            process_info(Pid, message_queue_len)
-          ]
-        }
-    end, registered()).
+    lists:map(
+        fun(ProcessName) ->
+            Pid = whereis(ProcessName),
+            {
+                ProcessName,
+                [
+                    process_info(Pid, memory),
+                    process_info(Pid, heap_size),
+                    process_info(Pid, stack_size),
+                    process_info(Pid, message_queue_len)
+                ]
+            }
+        end,
+        registered()
+    ).
 
 filtered_process_metrics() ->
-  process_metrics().
+    process_metrics().
 
 %% Gen server
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 init([]) ->
-  lager:debug("Starting ~p", [?MODULE]),
+    lager:debug("Starting ~p", [?MODULE]),
 
-  Dispatch = cowboy_router:compile(
-    [
-      {'_', 
+    Dispatch = cowboy_router:compile(
         [
-          {"/", erldns_metrics_root_handler, []}
+            {'_', [
+                {"/", erldns_metrics_root_handler, []}
+            ]}
         ]
-      }
-    ]
-  ),
+    ),
 
-  {ok, _} = cowboy:start_clear(?MODULE, [{port, port()}], #{env => #{dispatch => Dispatch}}),
+    {ok, _} = cowboy:start_clear(?MODULE, [{port, port()}], #{env => #{dispatch => Dispatch}}),
 
-  {ok, #state{}}.
+    {ok, #state{}}.
 
 handle_call(_Message, _From, State) ->
-  {reply, ok, State}.
+    {reply, ok, State}.
 handle_cast(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 handle_info(_, State) ->
-  {noreply, State}.
+    {noreply, State}.
 terminate(_, _) ->
-  ok.
+    ok.
 code_change(_PreviousVersion, State, _Extra) ->
-  {ok, State}.
+    {ok, State}.
 
 port() ->
- proplists:get_value(port, metrics_env(), ?DEFAULT_PORT).
+    proplists:get_value(port, metrics_env(), ?DEFAULT_PORT).
 
 metrics_env() ->
-  case application:get_env(erldns, metrics) of
-    {ok, MetricsEnv} -> MetricsEnv;
-    _ -> []
-  end.
-
+    case application:get_env(erldns, metrics) of
+        {ok, MetricsEnv} -> MetricsEnv;
+        _ -> []
+    end.

--- a/src/erldns_metrics_app.erl
+++ b/src/erldns_metrics_app.erl
@@ -20,10 +20,9 @@
 -export([start/2, stop/1]).
 
 start(_Type, _Args) ->
-  lager:debug("Starting erldns_metrics application"),
-  erldns_metrics_sup:start_link().
+    lager:debug("Starting erldns_metrics application"),
+    erldns_metrics_sup:start_link().
 
 stop(_State) ->
-  lager:info("Stop erldns_metrics application"),
-  ok.
-
+    lager:info("Stop erldns_metrics application"),
+    ok.

--- a/src/erldns_metrics_root_handler.erl
+++ b/src/erldns_metrics_root_handler.erl
@@ -22,30 +22,33 @@
 -behaviour(cowboy_rest).
 
 init(Req, State) ->
-  {cowboy_rest, Req, State}.
+    {cowboy_rest, Req, State}.
 
 content_types_provided(Req, State) ->
-  {[
-      {<<"text/html">>, to_html},
-      {<<"text/plain">>, to_text},
-      {<<"application/json">>, to_json}
-    ], Req, State}.
+    {
+        [
+            {<<"text/html">>, to_html},
+            {<<"text/plain">>, to_text},
+            {<<"application/json">>, to_json}
+        ],
+        Req,
+        State
+    }.
 
 to_html(Req, State) ->
-  {<<"erldns metrics">>, Req, State}.
+    {<<"erldns metrics">>, Req, State}.
 
 to_text(Req, State) ->
-  {<<"erldns metrics">>, Req, State}.
+    {<<"erldns metrics">>, Req, State}.
 
 to_json(Req, State) ->
-  Body = jsx:encode([{<<"erldns">>, 
-        [
-          {<<"metrics">>, erldns_metrics:filtered_metrics()},
-          {<<"stats">>, erldns_metrics:filtered_stats()},
-          {<<"vm">>, erldns_metrics:filtered_vm()},
-          {<<"ets">>, erldns_metrics:filtered_ets()},
-          {<<"processes">>, erldns_metrics:filtered_process_metrics()}
-        ]
-      }]),
-  {Body, Req, State}.
-
+    Body = jsx:encode([
+        {<<"erldns">>, [
+            {<<"metrics">>, erldns_metrics:filtered_metrics()},
+            {<<"stats">>, erldns_metrics:filtered_stats()},
+            {<<"vm">>, erldns_metrics:filtered_vm()},
+            {<<"ets">>, erldns_metrics:filtered_ets()},
+            {<<"processes">>, erldns_metrics:filtered_process_metrics()}
+        ]}
+    ]),
+    {Body, Req, State}.

--- a/src/erldns_metrics_sup.erl
+++ b/src/erldns_metrics_sup.erl
@@ -31,14 +31,12 @@
 %% Public API
 -spec start_link() -> any().
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
-
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 %% Callbacks
 init(_Args) ->
-  SysProcs = [
-    ?CHILD(erldns_metrics, worker, [])
-  ],
+    SysProcs = [
+        ?CHILD(erldns_metrics, worker, [])
+    ],
 
-  {ok, {{one_for_one, 20, 10}, SysProcs}}.
-
+    {ok, {{one_for_one, 20, 10}, SysProcs}}.


### PR DESCRIPTION
This is an attempt to define some consistent formatting rules for our Erlang code.

I made some research and I tested various options, so far the one that I prefer is [erlfmt](https://github.com/WhatsApp/erlfmt) from WhatsApp. Like most non-builtin formatters, this is opinionated. But the choices they made are well thought, and seem to be a good starting point.


You have both the option to reformat the code inline:

```
rebar3 fmt
```

or check the formatting:

```
rebar3 fmt --check
```

This last command is especially useful for CI integration.
