### PR TITLE
Adds CONTRIBUTING.md + adds Release CI action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -9,3 +11,4 @@ updates:
     labels:
       - task
       - dependencies
+      - automerge

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -1,3 +1,5 @@
+---
+
 name: Check Dependencies
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
+---
+
 name: CI
 
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
@@ -11,6 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  markdownlint-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.4.0
+        with:
+          files: .
+          config_file: ".markdownlint.yaml"
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run YAML Lint
+        uses: actionshub/yamllint@main
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -44,6 +66,8 @@ jobs:
 
     needs:
       - build
+      - markdownlint-cli
+      - yamllint
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+---
+
+name: Release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+---
+default: true
+
+# no-hard-tabs
+MD010:
+  code_blocks: false
+
+# no-multiple-blanks
+MD012:
+  maximum: 2
+
+# line-length
+MD013: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 256
+    level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## mai
+
+## 1.0.0
+
+### Changed
+
+- Bumps to OTP/27
+- Replaced "jsx" with "json"
+
+### Added
+
+- erlfmt
+- CONTRIBUTING.md
+- CHANGELOG.md
+- release process to hex.pm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to erldns-metrics
+
+## Getting started
+
+### 1. Clone the repository
+
+Clone the repository and move into it:
+
+```shell
+git clone git@github.com:dnsimple/erldns-metrics.git
+cd erldns-metrics
+```
+
+### 2. Install Erlang
+
+### 3. Install the dependencies
+
+```shell
+make
+```
+
+#### Updating Dependencies
+
+When dependencies are updated the rebar.lock file will need to be updated for the new dependency to be used. The following command does this:
+
+```shell
+./rebar3 upgrade --all
+```
+
+## Formatting
+
+If your editor doesn't automatically format Erlang code using [erlfmt](https://github.com/WhatsApp/erlfmt), run:
+
+```shell
+make format
+```
+
+You should run this command before releasing.
+
+### 3. Build and test
+
+Compile the project and [run the test suite](#testing) to check everything works as expected.
+
+## Testing
+
+```shell
+make test
+```
+
+## Releasing
+
+The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is a `MAJOR.MINOR.BUGFIX` release such as `1.2.0`.
+
+1. Run the test suite and ensure all the tests pass.
+
+1. Set the version in `src/erldns_metrics.app.src`
+
+1. Run the test suite and ensure all the tests pass.
+
+1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
+
+1. Commit and push the changes
+
+    ```shell
+    git commit -a -m "Release $VERSION"
+    git push origin main
+    ```
+
+1. Wait for CI to complete.
+
+1. Create a signed tag.
+
+    ```shell
+    git tag -a v$VERSION -s -m "Release $VERSION"
+    git push origin --tags
+    ```
+
+1. GitHub actions will take it from there and release to <https://hex.pm/packages/erldns_metrics>
+
+## Tests
+
+Submit unit tests for your changes. You can test your changes on your machine by [running the test suite](#testing).
+
+When you submit a PR, tests will also be run on the [continuous integration environment via GitHub Actions](https://github.com/dnsimple/dnsimple-ruby/actions/workflows/ci.yml).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,0 @@
-# Copyright (c) 2012-2025 DNSimple Corporation
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+# Copyright (c) 2012-2025 DNSimple Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This app provides an HTTP API for gathering and querying metrics from an [erldns] server and presenting those metrics as JSON.
 
+[![Build Status](https://github.com/dnsimple/erldns-metrics/actions/workflows/ci.yml/badge.svg)](https://github.com/dnsimple/erldns-metrics/actions/workflows/ci.yml)
+[![Module Version](https://img.shields.io/hexpm/v/erldns-metrics.svg)](https://hex.pm/packages/erldns-metrics)
+
 > [!NOTE]
 > erldns_metrics is architected to run in the *same Erlang VM* as erldns, as it reads metrics from the runtime. This is why erldns is a dependency of this library, and gets started in [`erldns_metrics.app.src`](./src/erldns_metrics.app.src): it's useful for local development, so that starting erldns_metrics also starts erldns.
 > In general, you might want to run erldns_metrics and erldns both as dependencies of an application that *you* control and deploy.


### PR DESCRIPTION
This PR adds the release process to https://hex.pm/packages/erldns_metrics

This is an effort on standardizing our Erlang repositories.

## :shipit: Deploy Steps

- [x] https://github.com/dnsimple/erldns-metrics/pull/22
- [x] https://github.com/dnsimple/erldns-metrics/pull/23
- [ ] Add `HEX_API_KEY` secret
- [ ] Merge
- [ ] Follow ./CONTRIBUTING.md guide to cut a 1.0.0 release

## :shipit: Verification Steps

- [ ] CI passing
- [ ] 3.0.0 is released to https://hex.pm/packages/erldns_metrics
