### PR TITLE
Set rebar3 in .tool-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,23 @@ jobs:
         uses: actionshub/yamllint@main
 
   test:
-    name: Test
-    runs-on: ubuntu-24.04
-    needs:
-      - markdownlint-cli
-      - yamllint
+    name: OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['27']
+        rebar3: ['3.24']
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          version-type: strict
-          version-file: .tool-versions
+          otp-version: ${{matrix.otp}}
+          rebar3-version: ${{matrix.rebar3}}
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/rebar3
             _build
-          key: ${{ runner.os }}-erlang-${{ steps.setup-beam.outputs.otp-version }}-rebar3-${{ steps.setup-beam.outputs.rebar3-version }}-hash-${{hashFiles('rebar.lock')}}
+          key: ${{ runner.os }}-erlang-${{ matrix.otp }}-rebar3-${{ matrix.rebar3 }}-hash-${{hashFiles('rebar.lock')}}
       - run: make build
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,55 +33,23 @@ jobs:
       - name: Run YAML Lint
         uses: actionshub/yamllint@main
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otp_version: ['27.1']
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: 'strict'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/rebar3
-            _build
-          key: ${{ runner.os }}-erlang-${{ matrix.otp_version }}-${{ hashFiles('**/*rebar.lock') }}
-
-      - run: make build
-
   test:
     name: Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otp_version: ['27.1']
-
+    runs-on: ubuntu-24.04
     needs:
-      - build
       - markdownlint-cli
       - yamllint
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: 'strict'
-
+          version-type: strict
+          version-file: .tool-versions
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/rebar3
             _build
-          key: ${{ runner.os }}-erlang-${{ matrix.otp_version }}-${{ hashFiles('**/*rebar.lock') }}
-
+          key: ${{ runner.os }}-erlang-${{ steps.setup-beam.outputs.otp-version }}-rebar3-${{ steps.setup-beam.outputs.rebar3-version }}-hash-${{hashFiles('rebar.lock')}}
+      - run: make build
       - run: make test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-# also update ci.yml
-erlang 27.2.3
-rebar 3.24.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 # also update ci.yml
-erlang 27.1.3
+erlang 27.2.3
+rebar 3.24.0

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,27 @@
-REBAR:=$(shell which rebar3 || echo ./rebar3)
-REBAR_URL:="https://s3.amazonaws.com/rebar3/rebar3"
-
 all: clean build
 
-$(REBAR):
-	wget $(REBAR_URL) && chmod +x rebar3
-
 .PHONY: build
-build: $(REBAR)
-	$(REBAR) compile
+build:
+	rebar3 compile
 
 .PHONY: clean
-clean: $(REBAR)
-	$(REBAR) clean
+clean:
+	rebar3 clean
 
 .PHONY: wipe
-wipe: $(REBAR)
+wipe:
 	rm -Rf _build
-	$(REBAR) clean
+	rebar3 clean
 
 .PHONY: fresh
 fresh: wipe build
 
 .PHONY: test
-test: $(REBAR)
-	$(REBAR) fmt --check
-	$(REBAR) ct
-	$(REBAR) dialyzer
+test:
+	rebar3 fmt --check
+	rebar3 ct
+	rebar3 dialyzer
 
 .PHONY: format
-format: $(REBAR)
-	$(REBAR) fmt
+format:
+	rebar3 fmt

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,8 @@
     {parse_transform, lager_transform}
 ]}.
 
+{minimum_otp_vsn, "27"}.
+
 {project_plugins, [
     erlfmt,
     rebar3_depup


### PR DESCRIPTION
Also update erlang and the way it is used in CI and enforce OTP27 in rebar.config, as we were already depending on features that only OTP27 uses (json).